### PR TITLE
Start DRB server in plugin run, not init

### DIFF
--- a/lib/adhearsion/drb/plugin.rb
+++ b/lib/adhearsion/drb/plugin.rb
@@ -21,7 +21,7 @@ module Adhearsion
       end
 
       # Include the DRb service in plugins initialization process
-      init :adhearsion_drb do
+      run :adhearsion_drb do
         Service.start
       end
 

--- a/spec/adhearsion/drb/plugin_spec.rb
+++ b/spec/adhearsion/drb/plugin_spec.rb
@@ -81,6 +81,7 @@ describe Adhearsion::Drb::Plugin do
       Adhearsion::Drb::Service.user_stopped = false
       Adhearsion::Drb::Service.should_receive(:start).and_return true
       Adhearsion::Plugin.init_plugins
+      Adhearsion::Plugin.run_plugins
     end
   end
 end


### PR DESCRIPTION
Fixes issue where e.g. you can't run rake when the app is running as it inits the plugin again and fails there.
