### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby-19mode
-  - rbx-2.1.1
+  - 2.3.1
+  - jruby
   - ruby-head
-matrix:
-  allow_failures:
-    - rvm: rbx-2.1.1
-    - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
   - 2.3.1
-  - jruby
   - ruby-head
+  - jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 rvm:
   - 2.3.1
   - ruby-head
-  - jruby
+  - jruby-9.1.2.0

--- a/adhearsion-drb.gemspec
+++ b/adhearsion-drb.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "jruby-openssl" if RUBY_PLATFORM == 'java'
 
+  s.add_development_dependency "adhearsion"
   s.add_development_dependency "rspec", "~> 2.7.0"
   s.add_development_dependency "flexmock"
   s.add_development_dependency "guard-rspec"

--- a/adhearsion-drb.gemspec
+++ b/adhearsion-drb.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "adhearsion", ["~> 2.0"]
-  s.add_runtime_dependency "i18n", ">= 0.5.0"
   s.add_runtime_dependency "jruby-openssl" if RUBY_PLATFORM == 'java'
 
   s.add_development_dependency "rspec", "~> 2.7.0"

--- a/adhearsion-drb.gemspec
+++ b/adhearsion-drb.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "jruby-openssl" if RUBY_PLATFORM == 'java'
+  s.add_runtime_dependency "adhearsion", "~> 3.0.0.rc1"
 
-  s.add_development_dependency "adhearsion"
-  s.add_development_dependency "rspec", "~> 2.7.0"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "flexmock"
   s.add_development_dependency "guard-rspec"
-  s.add_development_dependency "rake", ">= 0.9.2"
-  s.add_development_dependency "thor", "~> 0.14.0"
+  s.add_development_dependency "rake"
+  s.add_development_dependency "thor"
 end

--- a/lib/adhearsion/drb/plugin.rb
+++ b/lib/adhearsion/drb/plugin.rb
@@ -18,6 +18,7 @@ module Adhearsion
           allow ["127.0.0.1"], :desc => "list of valid IP addresses to access DRb service"
           deny  []           , :desc => "list of invalid IP addresses to access DRb service"
         }
+        verbose false, :desc => "DRb verbose mode"
       end
 
       # Include the DRb service in plugins initialization process

--- a/lib/adhearsion/drb/plugin.rb
+++ b/lib/adhearsion/drb/plugin.rb
@@ -18,7 +18,7 @@ module Adhearsion
           allow ["127.0.0.1"], :desc => "list of valid IP addresses to access DRb service"
           deny  []           , :desc => "list of invalid IP addresses to access DRb service"
         }
-        verbose false, :desc => "DRb verbose mode"
+        verbose "0", :desc => "DRb verbose mode"
       end
 
       # Include the DRb service in plugins initialization process

--- a/lib/adhearsion/drb/service.rb
+++ b/lib/adhearsion/drb/service.rb
@@ -18,7 +18,9 @@ module Adhearsion
       # Start the DRb service
       def start
         logger.info "Starting DRb on #{config.host}:#{config.port}"
-        DRb.start_service "druby://#{config.host}:#{config.port}", create_drb_door
+        service_config = {}
+        service_config.merge!(:verbose => config.verbose)
+        DRb.start_service "druby://#{config.host}:#{config.port}", create_drb_door, service_config
         logger.info "DRB Started on #{DRb.uri}"
         keep_service_running!
       end

--- a/lib/adhearsion/drb/service.rb
+++ b/lib/adhearsion/drb/service.rb
@@ -19,7 +19,7 @@ module Adhearsion
       def start
         logger.info "Starting DRb on #{config.host}:#{config.port}"
         service_config = {}
-        service_config.merge!(:verbose => config.verbose)
+        service_config.merge!(:verbose => config.verbose.to_i == 1)
         DRb.start_service "druby://#{config.host}:#{config.port}", create_drb_door, service_config
         logger.info "DRB Started on #{DRb.uri}"
         keep_service_running!

--- a/spec/adhearsion/drb/plugin_spec.rb
+++ b/spec/adhearsion/drb/plugin_spec.rb
@@ -6,23 +6,23 @@ describe Adhearsion::Drb::Plugin do
     subject { Adhearsion.config }
 
     it "should retrieve a valid configuration instance" do
-      Adhearsion.config.adhearsion_drb.should be_instance_of Loquacious::Configuration
+      expect(Adhearsion.config.adhearsion_drb).to be_instance_of Loquacious::Configuration
     end
 
     it "should listen on localhost by default" do
-      Adhearsion.config.adhearsion_drb.host.should == "localhost"
+      expect(Adhearsion.config.adhearsion_drb.host).to eq("localhost")
     end
 
     it "should use the default port of 9050" do
-      Adhearsion.config.adhearsion_drb.port.should == 9050
+      expect(Adhearsion.config.adhearsion_drb.port).to eq(9050)
     end
 
     it "should default to an empty deny acl" do
-      Adhearsion.config.adhearsion_drb.acl.deny.should have(0).hosts
+      expect(Adhearsion.config.adhearsion_drb.acl.deny.size).to eq(0)
     end
 
     it "should default to an allow acl of only 127.0.0.1" do
-      subject.adhearsion_drb.acl.allow.should == ["127.0.0.1"]
+      expect(subject.adhearsion_drb.acl.allow).to eq(["127.0.0.1"])
     end
 
   end
@@ -44,32 +44,32 @@ describe Adhearsion::Drb::Plugin do
 
     it "ovewrites properly the host value" do
       Adhearsion.config[:adhearsion_drb].host = "an-external-host"
-      Adhearsion.config[:adhearsion_drb].host.should == "an-external-host"
+      expect(Adhearsion.config[:adhearsion_drb].host).to eq("an-external-host")
     end
 
     it "ovewrites properly the port value" do
       Adhearsion.config[:adhearsion_drb].port = 9051
-      Adhearsion.config[:adhearsion_drb].port.should == 9051
+      expect(Adhearsion.config[:adhearsion_drb].port).to eq(9051)
     end
 
     it "ovewrites properly the allow access value" do
       Adhearsion.config[:adhearsion_drb].acl.allow = ["127.0.0.1", "192.168.10.*"]
-      Adhearsion.config[:adhearsion_drb].acl.allow.should == ["127.0.0.1", "192.168.10.*"]
+      expect(Adhearsion.config[:adhearsion_drb].acl.allow).to eq(["127.0.0.1", "192.168.10.*"])
     end
 
     it "ovewrites properly the allow access value adding an element" do
       Adhearsion.config[:adhearsion_drb].acl.allow << "192.168.10.*"
-      Adhearsion.config[:adhearsion_drb].acl.allow.should == ["127.0.0.1", "192.168.10.*"]
+      expect(Adhearsion.config[:adhearsion_drb].acl.allow).to eq(["127.0.0.1", "192.168.10.*"])
     end
 
     it "ovewrites properly the deny access value" do
       Adhearsion.config[:adhearsion_drb].acl.deny = ["192.168.*.*"]
-      Adhearsion.config[:adhearsion_drb].acl.deny.should == ["192.168.*.*"]
+      expect(Adhearsion.config[:adhearsion_drb].acl.deny).to eq(["192.168.*.*"])
     end
 
     it "ovewrites properly the deny access value adding an element" do
       Adhearsion.config[:adhearsion_drb].acl.deny << "192.168.*.*"
-      Adhearsion.config[:adhearsion_drb].acl.deny.should == ["192.168.*.*"]
+      expect(Adhearsion.config[:adhearsion_drb].acl.deny).to eq(["192.168.*.*"])
     end
   end
 
@@ -79,7 +79,7 @@ describe Adhearsion::Drb::Plugin do
 
     it "should start the service" do
       Adhearsion::Drb::Service.user_stopped = false
-      Adhearsion::Drb::Service.should_receive(:start).and_return true
+      expect(Adhearsion::Drb::Service).to receive(:start).and_return true
       Adhearsion::Plugin.init_plugins
       Adhearsion::Plugin.run_plugins
     end

--- a/spec/adhearsion/drb/service_spec.rb
+++ b/spec/adhearsion/drb/service_spec.rb
@@ -23,25 +23,25 @@ describe Adhearsion::Drb::Service do
   describe "while creating the acl value" do
 
     it "should return <allow 127.0.0.1> as default value" do
-      described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<allow 127.0.0.1>
+      expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<allow 127.0.0.1>)
     end
 
     it "should return an empty string when no rule is defined" do
       Adhearsion.config.adhearsion_drb.acl.allow = []
       Adhearsion.config.adhearsion_drb.acl.deny = []
-      described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == []
+      expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq([])
     end
 
     it "should return an empty string when allow and deny are nil" do
       Adhearsion.config.adhearsion_drb.acl.allow = nil
       Adhearsion.config.adhearsion_drb.acl.deny = nil
-      described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == []
+      expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq([])
     end
 
     it "should return an empty string when allow and deny are empty" do
       Adhearsion.config.adhearsion_drb.acl.allow = ""
       Adhearsion.config.adhearsion_drb.acl.deny = ""
-      described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == []
+      expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq([])
     end
 
     describe "having configured deny" do
@@ -51,12 +51,12 @@ describe Adhearsion::Drb::Service do
 
       it "should return an array with <deny 10.1.*.* deny 10.0.*.*>" do
         Adhearsion.config.adhearsion_drb.acl.deny = %w<10.1.*.* 10.0.*.*>
-        described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<deny 10.1.*.* deny 10.0.*.*>
+        expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<deny 10.1.*.* deny 10.0.*.*>)
       end
 
       it "should return an array with <deny 10.1.*.*>" do
         Adhearsion.config.adhearsion_drb.acl.deny = "10.1.*.*"
-        described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<deny 10.1.*.*>
+        expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<deny 10.1.*.*>)
       end
     end
 
@@ -67,12 +67,12 @@ describe Adhearsion::Drb::Service do
 
       it "should return an array with <allow 127.0.0.1 allow 10.0.0.1> when another IP is allowed" do
         Adhearsion.config.adhearsion_drb.acl.allow = %w<127.0.0.1 10.0.0.1>
-        described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<allow 127.0.0.1 allow 10.0.0.1>
+        expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<allow 127.0.0.1 allow 10.0.0.1>)
       end
 
       it "should return an array with <allow 10.0.0.1> when another IP is allowed" do
         Adhearsion.config.adhearsion_drb.acl.allow = "10.0.0.1"
-        described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<allow 10.0.0.1>
+        expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<allow 10.0.0.1>)
       end
     end
 
@@ -81,13 +81,13 @@ describe Adhearsion::Drb::Service do
       it "should return an array with <allow 127.0.0.1 allow 10.2.*.* deny 10.1.*.* deny 10.0.*.*>" do
         Adhearsion.config.adhearsion_drb.acl.allow = %w<127.0.0.1 10.2.*.*>
         Adhearsion.config.adhearsion_drb.acl.deny = %w<10.1.*.* 10.0.*.*>
-        described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<allow 127.0.0.1 allow 10.2.*.* deny 10.1.*.* deny 10.0.*.*>
+        expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<allow 127.0.0.1 allow 10.2.*.* deny 10.1.*.* deny 10.0.*.*>)
       end
 
       it "should return an array with <allow 127.0.0.1 deny 10.1.*.*>" do
         Adhearsion.config.adhearsion_drb.acl.allow = "127.0.0.1"
         Adhearsion.config.adhearsion_drb.acl.deny = "10.1.*.*"
-        described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny).should == %w<allow 127.0.0.1 deny 10.1.*.*>
+        expect(described_class.create_acl(Adhearsion.config.adhearsion_drb.acl.allow, Adhearsion.config.adhearsion_drb.acl.deny)).to eq(%w<allow 127.0.0.1 deny 10.1.*.*>)
       end
     end
   end
@@ -119,24 +119,24 @@ describe Adhearsion::Drb::Service do
     end
 
     it "should return normal Ruby data structures properly over DRb" do
-      client.foo.should == [3, 2, 1]
+      expect(client.foo).to eq([3, 2, 1])
     end
 
     it "should raise an exception for a non-existent interface" do
-      lambda { client.interface.bad_interface.should be [3, 2, 1] }.should raise_error NoMethodError
+      expect { expect(client.interface.bad_interface).to be [3, 2, 1] }.to raise_error NoMethodError
     end
 
     it "restarts the server if DRb's thread ends" do
       client.halt_drb_directly!
       sleep 2
-      client.foo.should == [3, 2, 1]
+      expect(client.foo).to eq([3, 2, 1])
     end
 
     it "does not start up again if Service.stop is called" do
-      Adhearsion::Drb::Service.should_not_receive :start
+      expect(Adhearsion::Drb::Service).not_to receive :start
       Adhearsion::Drb::Service.stop
       sleep 0.10
-      lambda { client.foo }.should raise_error DRb::DRbServerNotFound
+      expect { client.foo }.to raise_error DRb::DRbServerNotFound
     end
   end
 end

--- a/spec/adhearsion/drb_spec.rb
+++ b/spec/adhearsion/drb_spec.rb
@@ -6,7 +6,7 @@ module Adhearsion
     subject { Drb }
 
     it "should be a module" do
-      subject.should be_kind_of Module
+      expect(subject).to be_kind_of Module
     end
   end
 end


### PR DESCRIPTION
This PR removes i18n and adhearsion as runtime dependencies. This helped me when using this plugin with the latest version of Adherasion
